### PR TITLE
Fixed Vagrant and local browser integration bug while removing extra all() function

### DIFF
--- a/app/productmodel.py
+++ b/app/productmodel.py
@@ -109,8 +109,3 @@ class Product(db.Model):
         Product.logger.info(product_id)
         Product.logger.info(Product.query.get(product_id))
         return Product.query.get(product_id)
-
-    @staticmethod
-    def all():
-        Product.logger.info("Listing all products")
-        return Product.query.all()

--- a/run.py
+++ b/run.py
@@ -12,4 +12,4 @@ if __name__ == "__main__":
     productservice.initialize_logging()
     productservice.init_db()
     create_db.dbcreate()
-    app.run(host='127.0.0.1', port=int(PORT), debug=DEBUG)
+    app.run(host='0.0.0.0', port=int(PORT), debug=DEBUG)


### PR DESCRIPTION
**Important thing to note:

1. I have removed the extra all() function used to list all products from the productmodel.py file since @dingding2018 has already fixed that in her upcoming change

2. After this merge, to run the flask application from the ssh client inside vagrant, please use the command,

python run.py**